### PR TITLE
Graph and line stories v2

### DIFF
--- a/WPFTesting/SupplyChainTesting/AdvanceTimeTests.cs
+++ b/WPFTesting/SupplyChainTesting/AdvanceTimeTests.cs
@@ -237,7 +237,7 @@ internal class AdvanceTimeTests
         EndpointNode endpointTest = new EndpointNode()
         {
             Name = "Factory",
-            Profit = (decimal)10000
+            Balance = (decimal)10000
         };
         Shipment testShipment = new Shipment()
         {
@@ -264,7 +264,7 @@ internal class AdvanceTimeTests
         Assert.That(endpointTest.ComponentInventory.Count, Is.GreaterThan(0));
         Assert.That(endpointTest.ComponentInventory.First(x => x.ProductName == "Swedish fish").Quantity, Is.EqualTo(100));
         Assert.That(endpointTest.ComponentInventory.First(x => x.ProductName == "wood").Quantity, Is.EqualTo(100));
-        Assert.That(endpointTest.Profit, Is.EqualTo(9894.01));
+        Assert.That(endpointTest.Balance, Is.EqualTo(9894.01));
     }
 
     [Test]
@@ -282,7 +282,7 @@ internal class AdvanceTimeTests
                     Quantity = 10000
                 }
             },
-            Profit = 10000
+            Balance = 10000
         };
         List<Product> testOrder = new List<Product>()
         {
@@ -295,7 +295,7 @@ internal class AdvanceTimeTests
 
         endpointTest.ShipOrder(testOrder);
 
-        Assert.That(endpointTest.Profit, Is.EqualTo(10005.99));
+        Assert.That(endpointTest.Balance, Is.EqualTo(10005.99));
         Assert.That(endpointTest.ProductInventory.FirstOrDefault(x => x.ProductName == "Swedish fish").Quantity, Is.EqualTo(9900));
         }
     [Test]

--- a/WPFTesting/WPFTesting/FactorySADEfficiencyOptimizer.csproj
+++ b/WPFTesting/WPFTesting/FactorySADEfficiencyOptimizer.csproj
@@ -25,10 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.7.25103.5738" />
     <PackageReference Include="InteractiveDataDisplay.WPF" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WPFTesting/WPFTesting/MainWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ using FactorySADEfficiencyOptimizer.UIComponent;
 using System.Diagnostics;
 using FactorSADEfficiencyOptimizer.UIComponent;
 using FactorSADEfficiencyOptimizer.ViewModel;
+using FactorySADEfficiencyOptimizer.UIComponent.EventArguments;
 
 namespace YourNamespace
 {
@@ -925,10 +926,34 @@ namespace YourNamespace
             UnselectAllCanvasElements();
             if (sender is ShippingLine l)
             {
-                ViewModel.SelectedShipment = l.OwnShipment;
-                l.ourShippingLine.StrokeThickness = 5;
-                l.ourShippingLine.Stroke = new SolidColorBrush(Colors.PaleVioletRed);
-                LeftSidebarLineDetails.Visibility = Visibility.Visible;
+                SetSelectedShippingLine(l);
+            }
+        }
+
+        private void SetSelectedShippingLine(ShippingLine l)
+        {
+            ViewModel.SelectedShipment = l.OwnShipment;
+            l.ourShippingLine.StrokeThickness = 5;
+            l.ourShippingLine.Stroke = new SolidColorBrush(Colors.PaleVioletRed);
+            LeftSidebarLineDetails.Visibility = Visibility.Visible;
+        }
+
+        private void LineSelectedFromWindow_Click(object? sender, EventArgs e)
+        {
+            var selected = ((SelectedShipmentWindowMouseButtonEventArgs)e).selected;
+            if (ViewModel.ShipmentList.Any(x => x.Sender.Name == selected.Sender.Name && x.Receiver.Name == selected.Receiver.Name))
+            {
+                ViewModel.SelectedShipment = ViewModel.ShipmentList
+                                                      .Where(x => x.Sender.Name == selected.Sender.Name
+                                                              && x.Receiver.Name == selected.Receiver.Name).FirstOrDefault();
+
+                foreach (var line in DiagramCanvas.Children.OfType<ShippingLine>())
+                {
+                    if(line.OwnShipment == ViewModel.SelectedShipment)
+                    {
+                        SetSelectedShippingLine(line);
+                    }
+                }
             }
         }
 
@@ -974,6 +999,7 @@ namespace YourNamespace
             AnalysisWindow.Owner = this;
             AnalysisWindow.simModel = new AnalizorModel(ViewModel);
             AnalysisWindow.DataContext = AnalysisWindow.simModel;
+            AnalysisWindow.ShipmentHighlightPassoverHandler += LineSelectedFromWindow_Click;
             AnalysisWindow.Show();
         }
         private void Button_ClickForBillofMaterials(object sender, RoutedEventArgs e)
@@ -982,6 +1008,8 @@ namespace YourNamespace
             BillWindow.Owner = this;
             BillWindow.Show();
         }
+
+        
 
         private void IncrementShipmentDeliveryTime_Click(object sender, RoutedEventArgs e)
         {

--- a/WPFTesting/WPFTesting/Models/EndpointNode.cs
+++ b/WPFTesting/WPFTesting/Models/EndpointNode.cs
@@ -78,13 +78,13 @@ public class EndpointNode : IVendor, INotifyPropertyChanged
             OnPropertyChanged(nameof(DeliveryRequirementsList));
         }
     }
-    public decimal Profit
+    public decimal Balance
     {
         get => _profit;
         set
         {
             _profit = value;
-            OnPropertyChanged(nameof(Profit));
+            OnPropertyChanged(nameof(Balance));
         }
     }
 
@@ -192,7 +192,7 @@ public class EndpointNode : IVendor, INotifyPropertyChanged
                 toAdd.Quantity = product.Quantity;
                 ComponentInventory.Add(toAdd);
             }
-            Profit -= product.Price;
+            Balance -= product.Price;
         }
     }
 
@@ -204,10 +204,10 @@ public class EndpointNode : IVendor, INotifyPropertyChanged
             var targetindex = ProductInventory.ToList().FindIndex(x => x.ProductName == pitem.ProductName);
             if(ProductInventory[targetindex].Quantity - pitem.Quantity >= 0) {
                 ProductInventory[targetindex].Quantity -= pitem.Quantity;
-                Profit += (decimal)pitem.Quantity * ProductInventory[targetindex].Price;
+                Balance += (decimal)pitem.Quantity * ProductInventory[targetindex].Price;
             } 
             else {
-                Profit += (decimal)ProductInventory[targetindex].Quantity * ProductInventory[targetindex].Price;
+                Balance += (decimal)ProductInventory[targetindex].Quantity * ProductInventory[targetindex].Price;
                 ProductInventory[targetindex].Quantity = 0;
             }
         });

--- a/WPFTesting/WPFTesting/Shapes/EndpointUIValues.cs
+++ b/WPFTesting/WPFTesting/Shapes/EndpointUIValues.cs
@@ -23,7 +23,7 @@ namespace FactorySADEfficiencyOptimizer.Shapes
             supplier = new EndpointNode()
             {
                 Id = Guid.NewGuid(),
-                Profit = 1000,
+                Balance = 1000,
                 Name = "Factory",
                 ComponentInventory = new ObservableCollection<Product>()
                     {

--- a/WPFTesting/WPFTesting/UIComponent/Converters/CompletedDayConverter.cs
+++ b/WPFTesting/WPFTesting/UIComponent/Converters/CompletedDayConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace FactorySADEfficiencyOptimizer.UIComponent.Converters;
+
+[ValueConversion(typeof(int), typeof(string))]
+class CompletedDayConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is null)
+            return "not run";
+        int? day = (int)value;
+
+        return day.ToString() ?? throw new Exception("Converter failed to handle null value.");
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml.cs
@@ -50,9 +50,9 @@ namespace FactorySADEfficiencyOptimizer
         public void PopulateElementLists()
         {
             EndpointTitle.Text = NodeUIValues.supplier.Name;
-            ProfitTracker.Text = ((EndpointNode)(NodeUIValues.supplier)).Profit.ToString();
+            ProfitTracker.Text = ((EndpointNode)(NodeUIValues.supplier)).Balance.ToString();
 
-            if(((EndpointNode)(NodeUIValues.supplier)).Profit < 0)
+            if(((EndpointNode)(NodeUIValues.supplier)).Balance < 0)
             {
                 ProfitTracker.Foreground = Brushes.Red;
                 ProfitTrackerDollarSign.Foreground = Brushes.Red;

--- a/WPFTesting/WPFTesting/UIComponent/EventArguments/SelectedShipmentWindowMouseButtonEventArgs.cs
+++ b/WPFTesting/WPFTesting/UIComponent/EventArguments/SelectedShipmentWindowMouseButtonEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using FactorySADEfficiencyOptimizer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace FactorySADEfficiencyOptimizer.UIComponent.EventArguments
+{
+    public class SelectedShipmentWindowMouseButtonEventArgs : MouseButtonEventArgs
+    {
+        public Shipment selected {  get; private set; }
+        public SelectedShipmentWindowMouseButtonEventArgs(MouseDevice mouse, int timestamp, MouseButton button) : base(mouse, timestamp, button)
+        {
+        }
+
+        public void AssignSelectedShipment(Shipment shipment)
+        {
+            this.selected = shipment;
+        }
+    }
+}

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
@@ -9,7 +9,7 @@
         xmlns:converter="clr-namespace:FactorSADEfficiencyOptimizer.UIComponent.Converters"
         mc:Ignorable="d" DataContext="{Binding simModel}"
         Title="ProductionAnalysisWindow"
-        Height="450" Width="800"
+        Height="522" Width="1000"
         WindowStyle="ToolWindow">
     <Window.Background>
         <SolidColorBrush Color="DarkGray"></SolidColorBrush>
@@ -20,16 +20,23 @@
     </Window.Resources>
     <Grid Background="Transparent">
         <Grid.RowDefinitions>
+            <RowDefinition Height="72"></RowDefinition>
             <RowDefinition Height="3*"></RowDefinition>
             <RowDefinition Height="*"></RowDefinition>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="46*"></ColumnDefinition>
-            <ColumnDefinition Width="17*"></ColumnDefinition>
-            <ColumnDefinition Width="17*"></ColumnDefinition>
+            <ColumnDefinition Width="5*"></ColumnDefinition>
+            <ColumnDefinition Width="2*"></ColumnDefinition>
+            <ColumnDefinition Width="2*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
-
-        <Grid Grid.Column="0" Grid.RowSpan="2" Margin="0 0 4 10">
+        <StackPanel Grid.Row="0" Grid.Column="0">
+            <TextBlock Text="Production Targets:" FontSize="26" FontWeight="Bold"></TextBlock>
+            <TextBlock Text="1. Make production targets from your endpoint." FontWeight="SemiBold"></TextBlock>
+            <TextBlock Text="2. Run the simulation, and double-click on the status." FontWeight="SemiBold"></TextBlock>
+            
+        </StackPanel>
+        
+        <Grid Grid.Column="0" Grid.Row="1" Grid.RowSpan="2" Margin="0 0 4 10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="5*"></RowDefinition>
@@ -112,7 +119,7 @@
                     </ListView>
                 </StackPanel>
             </Border>
-            <Button Width="48" Height="48" VerticalAlignment="Bottom" Grid.RowSpan="2" HorizontalAlignment="Left"
+            <Button Padding="12 0 12 0" Height="48" VerticalAlignment="Bottom" Grid.RowSpan="2" HorizontalAlignment="Left"
                     Margin="20" Click="AddTargetButton_Click">
                 <Button.Style>
                     <Style TargetType="{x:Type Button}">
@@ -131,21 +138,24 @@
                     </Style>
                 </Button.Style>
                 <Button.Content>
-                    <TextBlock FontFamily="Verdana" FontWeight="UltraBold" FontSize="30" Margin="0 0 0 5">
-                        +
-                    </TextBlock>
+                    <DockPanel>
+                        <TextBlock Text="Add New Target" VerticalAlignment="Center" FontSize="16" FontWeight="SemiBold" Margin="0 0 0 3"></TextBlock>
+                        <TextBlock FontFamily="Verdana" FontWeight="UltraBold" FontSize="30" Margin="8 0 0 5">
+                            +
+                        </TextBlock>
+                    </DockPanel>
                 </Button.Content>
             </Button>
         </Grid>
 
-        <Grid Name="lines" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="4 0 0 0">
-            <Border Background="LightGray" BorderBrush="DarkGray" BorderThickness="1">
+        <Grid Name="lines" Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" Grid.ColumnSpan="2" Margin="4,0,0,108">
+            <Border Background="LightGray" BorderBrush="DarkGray" BorderThickness="1" Margin="10">
                 <d3:Chart x:Name="plotter" BottomTitle="Bottom" LeftTitle="Left">
                     <d3:LineGraph x:Name="linegraph" Stroke="RoyalBlue" StrokeThickness="3"/>
                 </d3:Chart>
             </Border>
         </Grid>
-        <Border Grid.Row="1" Grid.Column="1" Margin="4 4 0 10" BorderBrush="Bisque" BorderThickness="1" Background="SandyBrown" CornerRadius="6">
+        <Border Grid.Row="2" Grid.Column="1" Margin="4 4 0 10" BorderBrush="Bisque" BorderThickness="1" Background="SandyBrown" CornerRadius="6">
             <Button Background="Transparent" BorderThickness="0" x:Name="CheckShipmentButton"
                     Click="OpenShipmentWindow_Click">
                 <Button.Content>
@@ -158,7 +168,7 @@
                 </Button.Content>
             </Button>
         </Border>
-        <Border Grid.Row="1" Grid.Column="2" BorderBrush="SkyBlue" Background="DodgerBlue" BorderThickness="1" CornerRadius="50" Margin="5 5 5 10">
+        <Border Grid.Row="2" Grid.Column="2" BorderBrush="SkyBlue" Background="DodgerBlue" BorderThickness="1" CornerRadius="50" Margin="5,5,5,10">
             <Button Background="Transparent" BorderThickness="0" Click="StartSim_Click">
                 <Button.Content>
                     <StackPanel Orientation="Horizontal">

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
@@ -85,6 +85,7 @@
                                         <ColumnDefinition Width="4*"></ColumnDefinition>
                                         <ColumnDefinition Width="4*"></ColumnDefinition>
                                         <ColumnDefinition Width="4*"></ColumnDefinition>
+                                        <ColumnDefinition Width="4*"></ColumnDefinition>
                                         <ColumnDefinition Width="6*"></ColumnDefinition>
                                     </Grid.ColumnDefinitions>
                                     <CheckBox Grid.Column="0" IsChecked="{Binding IsTargetEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center"
@@ -99,7 +100,7 @@
                                             VerticalAlignment="Center"/>
                                         <Image Height="48">
                                             <Image.Source>
-                                                <BitmapImage DecodePixelHeight="48"
+                                                <BitmapImage DecodePixelHeight="24"
                                                              UriSource=".\Resources\UnrunTargetIcon.png">
                                                 </BitmapImage>
                                             </Image.Source>
@@ -140,7 +141,7 @@
         <Grid Name="lines" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="4 0 0 0">
             <Border Background="LightGray" BorderBrush="DarkGray" BorderThickness="1">
                 <d3:Chart x:Name="plotter" BottomTitle="Bottom" LeftTitle="Left">
-                    <d3:LineGraph x:Name="linegraph" Description="Simple linegraph" Stroke="RoyalBlue" StrokeThickness="3"/>
+                    <d3:LineGraph x:Name="linegraph" Stroke="RoyalBlue" StrokeThickness="3"/>
                 </d3:Chart>
             </Border>
         </Grid>

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:local="clr-namespace:FactorySADEfficiencyOptimizer.UIComponent"
         xmlns:classes="clr-namespace:FactorySADEfficiencyOptimizer.ViewModel"
         xmlns:d3="clr-namespace:InteractiveDataDisplay.WPF;assembly=InteractiveDataDisplay.WPF"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:converter="clr-namespace:FactorSADEfficiencyOptimizer.UIComponent.Converters"
         mc:Ignorable="d" DataContext="{Binding simModel}"
         Title="ProductionAnalysisWindow"
@@ -155,6 +156,14 @@
                 </d3:Chart>
             </Border>
         </Grid>
+
+        <Border Grid.Row="0" Grid.Column="0" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10">
+            <DockPanel>
+                <TextBlock Text="Pick a line color:" Margin="0 0 10 0"></TextBlock>
+                <xctk:ColorPicker Name="ClrPcker_Background" SelectedColorChanged="ClrPcker_Background_SelectedColorChanged"></xctk:ColorPicker>
+            </DockPanel>
+        </Border>
+        
         <Border Grid.Row="2" Grid.Column="1" Margin="4 4 0 10" BorderBrush="Bisque" BorderThickness="1" Background="SandyBrown" CornerRadius="6">
             <Button Background="Transparent" BorderThickness="0" x:Name="CheckShipmentButton"
                     Click="OpenShipmentWindow_Click">

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml
@@ -30,7 +30,7 @@
             <ColumnDefinition Width="2*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
         <StackPanel Grid.Row="0" Grid.Column="0">
-            <TextBlock Text="Production Targets:" FontSize="26" FontWeight="Bold"></TextBlock>
+            <TextBlock Text="Production Target Analysis:" FontSize="26" FontWeight="Bold"></TextBlock>
             <TextBlock Text="1. Make production targets from your endpoint." FontWeight="SemiBold"></TextBlock>
             <TextBlock Text="2. Run the simulation, and double-click on the status." FontWeight="SemiBold"></TextBlock>
             
@@ -65,11 +65,11 @@
                     <Border BorderThickness="0 0 0 1" BorderBrush="black">
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="3*"></ColumnDefinition>
                                 <ColumnDefinition Width="4*"></ColumnDefinition>
-                                <ColumnDefinition Width="6*"></ColumnDefinition>
-                                <ColumnDefinition Width="6*"></ColumnDefinition>
-                                <ColumnDefinition Width="8*"></ColumnDefinition>
+                                <ColumnDefinition Width="4*"></ColumnDefinition>
+                                <ColumnDefinition Width="7*"></ColumnDefinition>
+                                <ColumnDefinition Width="12*"></ColumnDefinition>
+                                <ColumnDefinition Width="10*"></ColumnDefinition>
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0" Text="Enabled"></TextBlock>
                             <TextBlock HorizontalAlignment="Left" Grid.Column="1" Text="Item"></TextBlock>

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
@@ -42,25 +42,14 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
             } 
         }
         public ProductionTarget TargetProductionTarget { get; set; }
-		private int _daystorun;
-        public int DaysToRun { 
-            get
-            {
-                return _daystorun;
-            }
-            set
-            {
-                _daystorun = value;
-                OnPropertyChanged(nameof(DaysToRun));
-            }
-        }
+
 
         public ProductionAnalysisWindow(SupplyChainViewModel model)
         {
             InitializeComponent();
             simModel = new AnalizorModel(model);
             this.DataContext = this;
-            DaysToRun = 1;
+            simModel.DaysToRun = 1;
             double[] x = new double[200];
             for (int i = 0; i < x.Length; i++)
                 x[i] = 3.1415 * i / (x.Length - 1);
@@ -68,10 +57,10 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
             for (int i = 0; i < 25; i++)
             {
                 var lg = new LineGraph();
-                linegraph.Children.Add(lg);
                 lg.Stroke = new SolidColorBrush(Color.FromArgb(255, 0, (byte)(i * 10), 0));
                 lg.Description = String.Format("Data series {0}", i + 1);
                 lg.StrokeThickness = 2;
+                linegraph.Children.Add(lg);
                 lg.Plot(x, x.Select(v => Math.Sin(v + i / 10.0)).ToArray());
             }
             //UpdatePlot();
@@ -84,13 +73,13 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
             if (AnalysisPeriodValue is null)
                 return;
 
-            if (DaysToRun >= 8)
+            if (simModel.DaysToRun >= 8)
             {
                 AnalysisPeriodValue.Background = new SolidColorBrush(Colors.AliceBlue);
             }
-            else if (DaysToRun < 1)
+            else if (simModel.DaysToRun < 1)
             {
-                DaysToRun = 1;
+                simModel.DaysToRun = 1;
                 AnalysisPeriodValue.Background = new SolidColorBrush(Colors.Transparent);
             }
             else
@@ -117,7 +106,9 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
             {
                 if (e.Key == Key.Enter)
                 {
-                    Int32.TryParse(textBox.Text, out _daystorun);
+                    int i = 0;
+                    Int32.TryParse(textBox.Text, out i);
+                    simModel.DaysToRun = i;
                     Keyboard.ClearFocus();
                 }
                 else if (e.Key == Key.Escape)
@@ -131,7 +122,9 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
         {
             if(sender is TextBox tb)
             {
-                Int32.TryParse(tb.Text, out _daystorun);
+                int i = 0;
+                Int32.TryParse(tb.Text, out i);
+                simModel.DaysToRun = i;
             }
         }
 
@@ -160,6 +153,13 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
         private void StartSim_Click(object? sender,  RoutedEventArgs? e)
         {
             simModel.PassTimeUntilDuration(simModel.DaysToRun);
+            linegraph.Children.Clear();
+
+        }
+
+        private void RenderLineResults()
+        {
+
         }
 
         private void OpenShipmentWindow_Click(object? sender, RoutedEventArgs? e)

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
     /// </summary>
     public partial class ProductionAnalysisWindow : Window, INotifyPropertyChanged
     {
+        public event EventHandler? ShipmentHighlightPassoverHandler;
         public double ProdTargetListWidth { get; set; }
         private AnalizorModel _simModel;
         public AnalizorModel simModel { 
@@ -161,6 +162,11 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
             RenderLineResults();
         }
 
+        private void LineSelectedFromWindow_MouseDown(object? sender, EventArgs? e)
+        {
+            ShipmentHighlightPassoverHandler?.Invoke(this, e);
+        }
+
         private void RenderLineResults()
         {
             double[] GraphDays = new double[(int)simModel.DaysToRun];
@@ -178,6 +184,7 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
             plotter.Title = "Balance-Per-Day during production.";
             plotter.PlotOriginX = 1;
             plotter.PlotOriginY = BalancePerDay.Min();
+            linegraph.IsAutoFitEnabled = true;
             linegraph.Children.Add(lg);
         }
 
@@ -194,6 +201,7 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
                 var ShipmentWindow = new ShipmentsScheduled(simModel);
                 ShipmentWindow.Owner = this;
                 ShipmentWindow.SaveShipmentDetails += ReworkShipmentSimulation;
+                ShipmentWindow.SelectShipmentLineHandler += LineSelectedFromWindow_MouseDown;
                 ShipmentWindow.Show();
             }
         }

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
@@ -158,7 +158,7 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
         {
             simModel.PassTimeUntilDuration(simModel.DaysToRun);
             linegraph.Children.Clear();
-
+            RenderLineResults();
         }
 
         private void RenderLineResults()
@@ -168,9 +168,23 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
             {
                 GraphDays[i] = i;
             }
+            double[] BalancePerDay = simModel.GetBalancePerDayForGraph();
+            var lg = new LineGraph();
+            lg.Stroke = GetIteratedLineColor();
+            lg.Description = "Financial State";
+            lg.StrokeThickness = 1;
+            plotter.BottomTitle = "Day";
+            plotter.LeftTitle = "Balance (in dollars)";
+            plotter.Title = "Balance-Per-Day during production.";
+            plotter.PlotOriginX = 1;
+            plotter.PlotOriginY = BalancePerDay.Min();
+            linegraph.Children.Add(lg);
+        }
 
-            
-
+        private SolidColorBrush GetIteratedLineColor()
+        {
+            Random random = new Random();
+            return new SolidColorBrush(Color.FromArgb(255, (byte)random.Next(0,255), (byte)random.Next(0, 255), (byte)random.Next(0, 255)));
         }
 
         private void OpenShipmentWindow_Click(object? sender, RoutedEventArgs? e)

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
@@ -231,6 +231,15 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
                 simModel.ShipmentList = new ObservableCollection<Shipment>(convertedShipments);
             }
         }
+
+        private void ClrPcker_Background_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e)
+        {
+            foreach (var item in linegraph.Children.OfType<LineGraph>())
+            {
+                if(e is not null)
+                    item.Stroke = new SolidColorBrush((Color)e.NewValue!);
+            }
+        }
         //private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
         //{
         //    ResizeAnyProductionTargetRows();

--- a/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/ProductionAnalysisWindow.xaml.cs
@@ -130,7 +130,14 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
 
         private void AddTargetButton_Click(object sender, RoutedEventArgs e)
         {
-            ProductionTarget newtarg = new ProductionTarget()
+            ProductionTarget newtarg = GetNewProductionTarget();
+            simModel.ProductionTargets.Add(newtarg);
+            OnPropertyChanged(nameof(simModel));
+        }
+
+        private static ProductionTarget GetNewProductionTarget()
+        {
+            return new ProductionTarget()
             {
                 DueDate = 3,
                 CurrentAmount = 0,
@@ -138,18 +145,15 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
                 Status = 0,
                 ProductTarget = new Product()
                 {
-                    ProductName = "New Product",
+                    ProductName = "Target item",
                     Price = 1,
                     Quantity = 1,
                     Units = ""
                 },
                 TargetQuantity = 1
-
             };
-            simModel.ProductionTargets.Add(newtarg);
-            //ResizeAnyProductionTargetRows();
-            OnPropertyChanged(nameof(simModel));
         }
+
         private void StartSim_Click(object? sender,  RoutedEventArgs? e)
         {
             simModel.PassTimeUntilDuration(simModel.DaysToRun);
@@ -159,6 +163,13 @@ namespace FactorySADEfficiencyOptimizer.UIComponent
 
         private void RenderLineResults()
         {
+            double[] GraphDays = new double[(int)simModel.DaysToRun];
+            for (int i = 0; i < simModel.DaysToRun; i++)
+            {
+                GraphDays[i] = i;
+            }
+
+            
 
         }
 

--- a/WPFTesting/WPFTesting/UIComponent/ShipmentsScheduled.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/ShipmentsScheduled.xaml
@@ -49,7 +49,7 @@
                     </Border>
                     <ListView x:Name="ScheduledShipmentsList" ItemsSource="{Binding Testshipments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                           SelectedItem="{Binding SelectedShipment}" SelectionChanged="ShipmentWindowList_SelectionChanged"
-                          Background="DarkGray">
+                          Background="DarkGray" PreviewMouseDown="SelectLineFromWindow_MouseDown">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <Grid>
@@ -61,7 +61,7 @@
                                         <ColumnDefinition Width="2*"></ColumnDefinition>
                                         <ColumnDefinition Width="*"></ColumnDefinition>
                                     </Grid.ColumnDefinitions>
-                                    <CheckBox IsChecked="{Binding IsRecurring}" Grid.Column="0"></CheckBox>
+                                    <CheckBox IsChecked="{Binding IsRecurring}" Grid.Column="0" Margin="0 2 0 0"></CheckBox>
                                     <TextBox Text="{Binding Sender.Name}" Grid.Column="1"></TextBox>
                                     <TextBox Text="{Binding Receiver.Name}" Grid.Column="2"></TextBox>
                                     <TextBox Text="{Binding TimeToDeliver}" Grid.Column="3"></TextBox>

--- a/WPFTesting/WPFTesting/UIComponent/ShipmentsScheduled.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/ShipmentsScheduled.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using FactorySADEfficiencyOptimizer.Models;
+using FactorySADEfficiencyOptimizer.UIComponent.EventArguments;
 
 namespace FactorSADEfficiencyOptimizer.UIComponent;
 
@@ -175,6 +176,17 @@ public partial class ShipmentsScheduled : Window
         if(sender is Button b)
         {
             AssignProductList((Shipment)b.DataContext);
+        }
+    }
+
+    public event EventHandler? SelectShipmentLineHandler;
+    private void SelectLineFromWindow_MouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is ListView b)
+        {
+            var shipmentSelectedEvent = new SelectedShipmentWindowMouseButtonEventArgs(e.MouseDevice, e.Timestamp, e.ChangedButton);
+            shipmentSelectedEvent.AssignSelectedShipment((Shipment)b.Items.CurrentItem);
+            SelectShipmentLineHandler?.Invoke(this, shipmentSelectedEvent);
         }
     }
 

--- a/WPFTesting/WPFTesting/ViewModel/AnalizorModel.cs
+++ b/WPFTesting/WPFTesting/ViewModel/AnalizorModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.Eventing.Reader;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Numerics;
@@ -195,7 +196,7 @@ public class AnalizorModel : INotifyPropertyChanged
 		end.Position = new System.Drawing.Point();
 		((EndpointNode)end.supplier).DeliveryRequirementsList = ((EndpointNode)endpoint.supplier).DeliveryRequirementsList;
 		((EndpointNode)end.supplier).ProductionList = ((EndpointNode)endpoint.supplier).ProductionList;
-		((EndpointNode)end.supplier).Profit = ((EndpointNode)endpoint.supplier).Profit;
+		((EndpointNode)end.supplier).Balance = ((EndpointNode)endpoint.supplier).Balance;
 		return end;
 	}
 
@@ -299,7 +300,7 @@ public class AnalizorModel : INotifyPropertyChanged
 			Product qp = new Product();
 			qp.ProductName = p.ProductName;
 			qp.Price = p.Price;
-			qp.Quantity = p.Quantity * newtarg.TargetQuantity;
+			qp.Quantity = (float)(p.Quantity * newtarg.TargetQuantity);
 			products.Add(qp);
 		}
 		return products;
@@ -391,5 +392,25 @@ public class AnalizorModel : INotifyPropertyChanged
 		}
 	}
 
+	public double[] GetQuantityPerDayForGraph(string ItemName)
+	{
+		return Snapshots.Where(x =>
+		{
+			return x.Targets.Exists(x =>
+			{
+				if (x.ProductTarget is not null)
+					return x.ProductTarget.ProductName == ItemName;
+				else return false;
+			});
+		})
+		.Select(x => (double)x.Targets.Sum(y => y.TargetQuantity)).ToArray();
+    }
 
+	public double[] GetBalancePerDayForGraph()
+	{
+		return Snapshots.Select<Snapshot,double>(x =>
+		{
+			return (double)x.Endpoints.Sum(item => ((EndpointNode)item.supplier).Balance);
+		}).ToArray();
+	}
 }

--- a/WPFTesting/WPFTesting/ViewModel/AnalizorModel.cs
+++ b/WPFTesting/WPFTesting/ViewModel/AnalizorModel.cs
@@ -336,8 +336,7 @@ public class AnalizorModel : INotifyPropertyChanged
 								{
 									Action = ActionEnum.addedShipment,
 									neededProduct = toOrder,
-								},
-								ProductionTarget = target,
+								}
 							};
 							IssueLog.Add(issue); 
 							ChangeLog.Add(new Change() { Action = ActionEnum.addedShipment, neededProduct = toOrder, shipmentReceiver = endpoint });

--- a/WPFTesting/WPFTesting/ViewModel/AnalizorModel.cs
+++ b/WPFTesting/WPFTesting/ViewModel/AnalizorModel.cs
@@ -390,4 +390,6 @@ public class AnalizorModel : INotifyPropertyChanged
 			}
 		}
 	}
+
+
 }


### PR DESCRIPTION
+ Added logic to highlight line from Selected Shipment window, per Epic 1 requirement: [Shipments Scheduled] (# 4) Select shipment takes user to graph with highlighted shipment/supplier.
+ Added logic to analyze balance per day after the analysis algorithm runs, as per issue #126 and Epic 1 requirements: [Production Target Window] (# 3) Displays Data ((In a graph)), and [Graph Window] (# 1) Easy to Understand, (# 2) Labeled axes, (# 3) Customizable Colors, (# 4) Shows Math Model.
+ Added Color picker for graph that recolors the lines at will, and package to allow other recoloring abilities.