### PR TITLE
User feedback round 2: List items in Supplier open details.

### DIFF
--- a/WPFTesting/WPFTesting/MainWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/MainWindow.xaml.cs
@@ -147,7 +147,7 @@ public MainWindow()
     private void MakeNewEndpoint()
 	{
 		EndpointUIValues EUIV = new EndpointUIValues();
-		EUIV.SetDefaultValues();
+		//EUIV.SetDefaultValues();
 		AddEndpointToCanvas(EUIV);
 		ViewModel.AddEndpointToChain(EUIV);
 	}
@@ -162,6 +162,7 @@ public MainWindow()
 		element.RadialClicked += FinishConnection_Click;
 		element.ElementClicked += SelectEndpoint_Click;
         element.EndpointDeleted += RemoveEndpoint;
+        element.InventoryItemClicked += OpenEndpointDetails_SubElement_Event;
 
 		Canvas.SetLeft(element, EUIV.Position.X);
 		Canvas.SetTop(element, EUIV.Position.Y);
@@ -673,6 +674,11 @@ public MainWindow()
         }
     }
 
+    private void OpenEndpointDetails_SubElement_Event(object? sender, EventArgs e)
+    {
+        OpenEndpointDetails();
+    }
+
     private void OpenSupplierInventory_Click(object sender, RoutedEventArgs e)
     {
         if(sender is Button s)
@@ -1146,21 +1152,26 @@ public MainWindow()
         BillWindow.Show();
     }
 
-        private void OpenEndpointDetailsWindowButton_Click(object sender, RoutedEventArgs e)
-        {
-            var EndpointDetails = new EndpointDetailsWindow(((EndpointNode)ViewModel.SelectedEndpoint.Supplier));
+    private void OpenEndpointDetailsWindowButton_Click(object sender, RoutedEventArgs e)
+    {
+        OpenEndpointDetails();
+    }
 
-            //EndpointDetails.EndpointVM.ProductInventory = ViewModel.SelectedEndpoint.Supplier.ProductInventory;
-            //EndpointDetails.EndpointVM.ComponentInventory = ViewModel.SelectedEndpoint.Supplier.ComponentInventory;
-            //EndpointDetails.EndpointVM.ProductionList = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ProductionList;
-            //EndpointDetails.EndpointVM.ActiveDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ActiveDeliveryLines;
-            //EndpointDetails.EndpointVM.PastDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).PastDeliveryLines;
+    private void OpenEndpointDetails()
+    {
+        var EndpointDetails = new EndpointDetailsWindow(((EndpointNode)ViewModel.SelectedEndpoint.Supplier));
 
-            EndpointDetails.Owner = this;
-            EndpointDetails.Show();
-        }
+        //EndpointDetails.EndpointVM.ProductInventory = ViewModel.SelectedEndpoint.Supplier.ProductInventory;
+        //EndpointDetails.EndpointVM.ComponentInventory = ViewModel.SelectedEndpoint.Supplier.ComponentInventory;
+        //EndpointDetails.EndpointVM.ProductionList = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ProductionList;
+        //EndpointDetails.EndpointVM.ActiveDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ActiveDeliveryLines;
+        //EndpointDetails.EndpointVM.PastDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).PastDeliveryLines;
 
-        private void IncrementShipmentDeliveryTime_Click(object sender, RoutedEventArgs e)
+        EndpointDetails.Owner = this;
+        EndpointDetails.Show();
+    }
+
+    private void IncrementShipmentDeliveryTime_Click(object sender, RoutedEventArgs e)
         {
             if(ViewModel is not null && ViewModel.SelectedShipment is not null)
                 ViewModel.SelectedShipment.TimeToDeliver++;

--- a/WPFTesting/WPFTesting/MainWindow.xaml.cs
+++ b/WPFTesting/WPFTesting/MainWindow.xaml.cs
@@ -88,13 +88,7 @@ public MainWindow()
                 Canvas.SetLeft(dBox, box.Position.X);
                 Canvas.SetTop(dBox, box.Position.Y);
 
-                dBox.MouseDown += Box_MouseDown;
-                dBox.BoxChanged += Box_Position_Changed;
-                dBox.RadialClickedTop += StartConnection_Click;
-                dBox.RadialClickedTop += FinishConnection_Click;
-                dBox.RadialClickedBottom += StartConnection_Click;
-                dBox.RadialClickedBottom += FinishConnection_Click;
-                dBox.BoxDeleted += RemoveSupplier;
+                dBox = AssignEventsToSupplier(dBox);
 
                 AddBoxToTracker(dBox);
 
@@ -278,18 +272,25 @@ public MainWindow()
         SupplierElement newBox = new SupplierElement(b);
         Canvas.SetLeft(newBox, b.Position.X);
         Canvas.SetTop(newBox, b.Position.Y);
-        newBox.Width = 100;
-        newBox.Height = 50;
-        newBox.MouseDown += Box_MouseDown;
-        newBox.BoxChanged += Box_Position_Changed;
-        newBox.RadialClickedTop += StartConnection_Click;
-        newBox.RadialClickedTop += FinishConnection_Click;
-        newBox.BoxDeleted += RemoveSupplier;
+        newBox = AssignEventsToSupplier(newBox);
 
         AddBoxToTracker(newBox);
 
         ViewModel.AddSupplierToChain(b); // // // // //
         DiagramCanvas.Children.Add(newBox);
+    }
+
+    public SupplierElement AssignEventsToSupplier(SupplierElement supplier)
+    {
+        supplier.MouseDown += Box_MouseDown;
+        supplier.BoxChanged += Box_Position_Changed;
+        supplier.RadialClickedTop += StartConnection_Click;
+        supplier.RadialClickedTop += FinishConnection_Click;
+        supplier.RadialClickedBottom += StartConnection_Click;
+        supplier.RadialClickedBottom += FinishConnection_Click;
+        supplier.InventoryItemClicked += OpenSupplierInventory_SubElement_Event;
+        supplier.BoxDeleted += RemoveSupplier;
+        return supplier;
     }
 
     private void AddBoxToTracker(SupplierElement box)
@@ -676,12 +677,23 @@ public MainWindow()
     {
         if(sender is Button s)
         {
-            SupplierInventoryWindow DetailsWindow = new SupplierInventoryWindow().WithViewModel(((Supplier)((SupplyChainViewModel)s.DataContext).SelectedSupplier.Supplier));
-            DetailsWindow.Owner = this;
-            DetailsWindow.SaveSupplierHandler += SaveSupplierDetails;
-            DetailsWindow.Show();
+            OpenSupplierInventory((Supplier)((SupplyChainViewModel)s.DataContext).SelectedSupplier!.Supplier);
         }
+    }
 
+    private void OpenSupplierInventory_SubElement_Event(object? sender, EventArgs e)
+    {
+        if(e is SaveSupplierEventArgs s)
+        OpenSupplierInventory(s.supplier!);
+    }
+
+    public void OpenSupplierInventory(Supplier supp)
+    {
+        SupplierInventoryWindow DetailsWindow = new SupplierInventoryWindow()
+            .WithViewModel(supp);
+        DetailsWindow.Owner = this;
+        DetailsWindow.SaveSupplierHandler += SaveSupplierDetails;
+        DetailsWindow.Show();
     }
 
     private void OpenCommonProductWindow_Click(object sender, RoutedEventArgs e)
@@ -1138,11 +1150,11 @@ public MainWindow()
         {
             var EndpointDetails = new EndpointDetailsWindow(((EndpointNode)ViewModel.SelectedEndpoint.Supplier));
 
-            EndpointDetails.EndpointVM.ProductInventory = ViewModel.SelectedEndpoint.Supplier.ProductInventory;
-            EndpointDetails.EndpointVM.ComponentInventory = ViewModel.SelectedEndpoint.Supplier.ComponentInventory;
-            EndpointDetails.EndpointVM.ProductionList = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ProductionList;
-            EndpointDetails.EndpointVM.ActiveDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ActiveDeliveryLines;
-            EndpointDetails.EndpointVM.PastDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).PastDeliveryLines;
+            //EndpointDetails.EndpointVM.ProductInventory = ViewModel.SelectedEndpoint.Supplier.ProductInventory;
+            //EndpointDetails.EndpointVM.ComponentInventory = ViewModel.SelectedEndpoint.Supplier.ComponentInventory;
+            //EndpointDetails.EndpointVM.ProductionList = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ProductionList;
+            //EndpointDetails.EndpointVM.ActiveDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).ActiveDeliveryLines;
+            //EndpointDetails.EndpointVM.PastDeliveryLines = ((EndpointNode)ViewModel.SelectedEndpoint.Supplier).PastDeliveryLines;
 
             EndpointDetails.Owner = this;
             EndpointDetails.Show();

--- a/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml
@@ -128,7 +128,7 @@
                             <Grid>
                                 <StackPanel Orientation="Horizontal" Margin="3 1 0 0">
                                     <TextBlock Text="Company Savings: $" x:Name="ProfitTrackerDollarSign"></TextBlock>
-                                    <TextBlock x:Name="ProfitTracker" Text="{Binding Supplier.Profit, Mode=OneWay, StringFormat={}{0}}" HorizontalAlignment="Left" Margin="1 0 0 0" MaxWidth="250"></TextBlock>
+                                    <TextBlock x:Name="ProfitTracker" Text="{Binding Profit, Mode=OneWay, StringFormat={}{0}}" HorizontalAlignment="Left" Margin="1 0 0 0" MaxWidth="250"></TextBlock>
                                     
                                 </StackPanel>
                                 <Border BorderBrush="DimGray" Width="18" Height="18" BorderThickness="0 0 2 2" HorizontalAlignment="Right" Margin="0 0 2 0" CornerRadius="1">

--- a/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml
@@ -57,7 +57,8 @@
                                 </TextBlock>
                                 <ListView
                                     ItemsSource="{Binding Supplier.ComponentInventory, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                    SelectedItem="{Binding Product}" x:Name="ComponentsList"
+                                    SelectedItem="{Binding Product}" x:Name="ComponentsList" PreviewMouseUp="OpenDetails_PreviewMouseUp"
+                                    MouseDoubleClick="OpenDetails_MouseDoubleClick" VerticalAlignment="Stretch"
                                     Grid.Row="1" Margin="-1 0 -1 0" BorderBrush="gray" BorderThickness="1 1 1 0">
                                     <ListView.View>
                                         <GridView >
@@ -94,7 +95,8 @@
                                 </TextBlock>
                                 <ListView
                                     ItemsSource="{Binding Supplier.ProductInventory, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                    SelectedItem="{Binding Product}" x:Name="ProductsList"
+                                    SelectedItem="{Binding Product}" x:Name="ProductsList"  PreviewMouseUp="OpenDetails_PreviewMouseUp"
+                                    MouseDoubleClick="OpenDetails_MouseDoubleClick" VerticalAlignment="Stretch"
                                     Grid.Row="1" Margin="-1 0 -1 0" BorderBrush="Gray" BorderThickness="1 1 1 0">
                                     <ListView.View>
                                         <GridView >

--- a/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/EndpointElement.xaml.cs
@@ -180,5 +180,24 @@ namespace FactorySADEfficiencyOptimizer
 
             ElementBackground.Background = new SolidColorBrush(newValue);
         }
+
+        public event EventHandler? InventoryItemClicked;
+        private void OpenDetails_PreviewMouseUp(object? sender, MouseButtonEventArgs e)
+        {
+            OpenDetails();
+        }
+
+        private void OpenDetails()
+        {
+            InventoryItemClicked?.Invoke(this, new SendEndpointDetailsEventArgs()
+            {
+                EndpointModel = (EndpointNode)EndpointVM.Supplier
+            });
+        }
+
+        private void OpenDetails_MouseDoubleClick(object? sender, MouseButtonEventArgs e)
+        {
+            OpenDetails();
+        }
     }
 }

--- a/WPFTesting/WPFTesting/UIComponent/EventArguments/SendEndpointDetailsEventArgs.cs
+++ b/WPFTesting/WPFTesting/UIComponent/EventArguments/SendEndpointDetailsEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using FactorySADEfficiencyOptimizer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace FactorySADEfficiencyOptimizer.UIComponent.EventArguments
+{
+    public class SendEndpointDetailsEventArgs : EventArgs
+    {
+        public EndpointNode? EndpointModel;
+    }
+}

--- a/WPFTesting/WPFTesting/UIComponent/SupplierElement.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/SupplierElement.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
              xmlns:viewmodel="clr-namespace:FactorySADEfficiencyOptimizer.ViewModel" 
+             MinWidth="160" MinHeight="200"
              Width="200" Height="200" DataContext="{Binding SupplierVM}">
     <Grid ClipToBounds="False" x:Name="SupplierPrimaryGrid">
         <Grid.RowDefinitions>
@@ -80,7 +81,7 @@
                         </StackPanel>
                     </ItemsControl>-->
                     <ListView ItemsSource="{Binding Supplier.ProductInventory, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                              SelectedItem="{Binding Product}"
+                              SelectedItem="{Binding Product}" PreviewMouseUp="OpenInventory_PreviewMouseUp" MouseDoubleClick="OpenInventory_MouseDoubleClick"
                               x:Name="ItemsList" Grid.Row="1">
                         <ListView.View>
                             <GridView AllowsColumnReorder="true" ColumnHeaderToolTip="Product Information">

--- a/WPFTesting/WPFTesting/UIComponent/SupplierElement.xaml.cs
+++ b/WPFTesting/WPFTesting/UIComponent/SupplierElement.xaml.cs
@@ -155,6 +155,19 @@ namespace YourNamespace
         {
             base.OnRender(drawingContext);
         }
+
+        public event EventHandler? InventoryItemClicked;
+        private void OpenInventory_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var SuppEventArgs = new SaveSupplierEventArgs() { supplier = (Supplier)_nodeUIValues.Supplier };
+            InventoryItemClicked?.Invoke(this, SuppEventArgs);
+        }
+        private void OpenInventory_PreviewMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            var SuppEventArgs = new SaveSupplierEventArgs() { supplier = (Supplier)_nodeUIValues.Supplier };
+            InventoryItemClicked?.Invoke(this, SuppEventArgs);
+        }
+
     }
 
     public class BoxConnection : BoxConnectionBase

--- a/WPFTesting/WPFTesting/UIComponent/SupplierInventoryWindow.xaml
+++ b/WPFTesting/WPFTesting/UIComponent/SupplierInventoryWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:FactorySADEfficiencyOptimizer.UIComponent"
         xmlns:converter="clr-namespace:FactorSADEfficiencyOptimizer.UIComponent.Converters"
         mc:Ignorable="d" DataContext="{Binding SupplierVM}"
-        Title="SupplierInventoryWindow" Height="300" Width="400"
+        Title="{Binding Name, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Height="300" Width="400"
         Background="DarkGray">
     <Window.Resources>
         <converter:MarginConverter x:Key="marginConverter"></converter:MarginConverter>


### PR DESCRIPTION
+ Added line to enforce the rule that Supplier elements generate with a minimum readable size.
+ Added events to SupplierElement to open a SupplierInventory window when the list of products, or the list view, is clicked or double clicked.
~ Refactoring to box event assignment - duplicated event signing produced degraded, uneven event assignment.